### PR TITLE
fix: typo of value auto in 22-absolute-removal

### DIFF
--- a/4-layout/22-absolute-removal/styles.css
+++ b/4-layout/22-absolute-removal/styles.css
@@ -24,7 +24,7 @@ nav > ul {
 nav li {
  background-color: #c2c2ff;
   padding: 7px;
-  margin: 1em atuo;
+  margin: 1em auto;
   width: 25%;
   border: 2px solid;
   border-radius: 5px;


### PR DESCRIPTION
# PR description:
- This PR fixes a bug related to a typo found in the CSS for exercise `22-absolute-removal`.
  - In `nav li`, value `auto` is misspelled as `atuo`.

## Changes made:
- Spelling for value `auto` was corrected.

## Issue related:
- This PR closes #8.