### PR TITLE
fix: missing title

### DIFF
--- a/2-properties/12-invitation/index.html
+++ b/2-properties/12-invitation/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
  <link href="styles.css" rel="stylesheet" />
- <title></title>
+ <title>Invitation</title>
 </head>
 <body>
  <div id="invite-wrapper">


### PR DESCRIPTION
## Missing title for `title` tag
- This PR fixes a missing title found in the source code for [12-invitation](https://github.com/codedex-io/css-101/blob/main/2-properties/12-invitation/index.html).

### Changes:
- Added a title of `Invitation` to the `title` tag.

### Screenshot of changes:
<img width="325" alt="image" src="https://github.com/codedex-io/css-101/assets/140430987/8cdbc5a6-1ccd-4f70-bd35-c00ea8291105">

### Related issue:
- This PR closes #17.