### PR TITLE
fix: ID attribute name

### DIFF
--- a/3-box-model/18-local-library/styles.css
+++ b/3-box-model/18-local-library/styles.css
@@ -46,7 +46,7 @@ section {
   margin: 0 5em;
 }
 
-#catalog-input, #forn-btn {
+#catalog-input, #form-btn {
   text-align: center;
   font-size: 1.25rem;
   font-weight: 800;


### PR DESCRIPTION
## Fix: `ID` attribute name
- This PR fixes a typo found in [18-local-library](https://github.com/codedex-io/css-101/blob/main/3-box-model/18-local-library/styles.css), the word `form` is misspelled as `forn`.
  - `ID` attribute name in `index.html` now correctly matches `#form-btn`.

## Changes:
- `ID` attribute name has been corrected from `#forn-btn` to `#form-btn`.

## Screenshot with changes:
<img width="284" alt="image" src="https://github.com/codedex-io/css-101/assets/140430987/1e81b805-acfa-48e4-a4fa-c48483f7f37b">

## Related issues:
- This PR closes #19.