### PR TITLE
Fix/double identical id names#21

### DIFF
--- a/4-layout/25-art-gallery/starter/index.html
+++ b/4-layout/25-art-gallery/starter/index.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <div id="gallery-header">
-    <h1 id="gallery-header">Museum Gallery</h1>
+    <h1>Museum Gallery</h1>
     <p>How Will You Arrange Your Visit?</p>
   </div>
   <hr>

--- a/4-layout/25-art-gallery/starter/styles.css
+++ b/4-layout/25-art-gallery/starter/styles.css
@@ -24,6 +24,7 @@ hr {
 }
 
 #gallery-header > h1 {
+  padding-bottom: 6px;
   margin-left: 0;
 }
 


### PR DESCRIPTION
# Fix: Double identical `ID` attribute names
- This PR adds 2 fixes to both the `index.html` and `styles.css`.

## Changes
- Removed a second identical `ID` attribute name found in `index.html`, as the `ID` attribute **must be unique** within a document.
- To accommodate this change I have added the required padding initially intended for the `H1` tag to have. This keeps the initial styling of `index.html` the same while addressing the  identical `ID` attribute name found in `index.html`.

## Related issues:
- This PR closes #21.