### PR TITLE
fix: add missing border properties

### DIFF
--- a/3-box-model/18-local-library/styles.css
+++ b/3-box-model/18-local-library/styles.css
@@ -54,7 +54,7 @@ section {
 }
 
 #catalog-input {
-  border: 2px;
+  border: 2px solid black;
   width: 37.5%;
 }
 
@@ -63,7 +63,7 @@ section {
 }
 
 .staff-pick-img {
-  border: 1px;
+  border: 1px solid black;
   border-radius: 0 7px 7px 0;
   width: 10em;
   height: 10em;


### PR DESCRIPTION
## Fix: Add missing border properties
- This PR fixes a bug that occurs from two missing border properties, `style` and `color`.

### Changes:
- Added border properties `style` and `color` to `#catalog-input` and `.staff-pick-img`.

### Expected behavior:
- Both input for searching the catalog and the staff pick images properly display their borders.

### After changes:
<img width="611" alt="image" src="https://github.com/codedex-io/css-101/assets/140430987/18e57f96-3990-4f62-bad9-7b2ea148ff07">

### Before changes:
<img width="606" alt="image" src="https://github.com/codedex-io/css-101/assets/140430987/d40ebd5d-51da-48f7-9295-1c10737c1eb6">

### Related issues:
- This PR closes #25.