### PR TITLE
fix: semantic issue in 17-make-it-count

### DIFF
--- a/3-box-model/17-make-it-count/index.html
+++ b/3-box-model/17-make-it-count/index.html
@@ -5,7 +5,9 @@
   <img id="top-img" src="https://images.unsplash.com/photo-1551027654-f7b9f56804c7?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=687&q=80" style="width:10em; height:10em;" />
 
   <ul id="post-list">
-    <h2>My Feed</h2>
+    <li>
+      <h2>My Feed</h2>
+    </li>
     <li>
       <div class="post-wrapper">
         <img class="post-img" src="https://www.carnegielibrary.org/wp-content/uploads/2016/02/CLPMain_1080x600.jpg" alt="Carnegie Library of Pittsburgh" style="width:100%;" />

--- a/3-box-model/17-make-it-count/index.html
+++ b/3-box-model/17-make-it-count/index.html
@@ -4,10 +4,8 @@
 <div id="outside-wrapper" style="width:80%;">
   <img id="top-img" src="https://images.unsplash.com/photo-1551027654-f7b9f56804c7?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=687&q=80" style="width:10em; height:10em;" />
 
+  <h2>My Feed</h2>
   <ul id="post-list">
-    <li>
-      <h2>My Feed</h2>
-    </li>
     <li>
       <div class="post-wrapper">
         <img class="post-img" src="https://www.carnegielibrary.org/wp-content/uploads/2016/02/CLPMain_1080x600.jpg" alt="Carnegie Library of Pittsburgh" style="width:100%;" />


### PR DESCRIPTION
## Fix: Improper use of `h3` tag inside `ul`
- This PR fixes an improper use of an `h3` tag inside a `ul` tag.

### Changes:
- `h3` tag has been wrapped inside of a `li` tag.
  - Note: The CSS removes the user list style added after wrapping the `h3` tag in a `li` tag.
  
### Related issues:
- This PR closes #27.