### PR TITLE
Fix: Move <h2> outside of <ul> for improved semantic structure

### DIFF
--- a/3-box-model/16-spaced-out/index.html
+++ b/3-box-model/16-spaced-out/index.html
@@ -1,20 +1,36 @@
 <!-- Spaced Out 🛰️ -->
 <!-- Codédex -->
 
-<div id="outside-wrapper" style="width:80%;">
-  <img id="top-img" src="https://images.unsplash.com/photo-1551027654-f7b9f56804c7?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=687&q=80" style="width:10em; height:10em;" />
+<div id="outside-wrapper" style="width: 80%">
+  <img
+    id="top-img"
+    src="https://images.unsplash.com/photo-1551027654-f7b9f56804c7?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=687&q=80"
+    style="width: 10em; height: 10em"
+  />
 
+  <h2>My Feed</h2>
   <ul id="post-list">
-    <h2>My Feed</h2>
     <li>
       <div class="post-wrapper">
-        <img class="post-img" src="https://www.carnegielibrary.org/wp-content/uploads/2016/02/CLPMain_1080x600.jpg" alt="Carnegie Library of Pittsburgh" style="width:100%;" />
-        <p>Visited the library! 📚 <b>#libraries</b> <b>#readingisawesome</b></p>
+        <img
+          class="post-img"
+          src="https://www.carnegielibrary.org/wp-content/uploads/2016/02/CLPMain_1080x600.jpg"
+          alt="Carnegie Library of Pittsburgh"
+          style="width: 100%"
+        />
+        <p>
+          Visited the library! 📚 <b>#libraries</b> <b>#readingisawesome</b>
+        </p>
       </div>
     </li>
     <li>
       <div class="post-wrapper">
-        <img class="post-img" src="https://media.giphy.com/media/AFHFoEv9fDOn7lIdlD/giphy.gif" alt="GIF of two people fist-bumbing with the caption 'YOU GOT THIS'" style="width:100%;" />
+        <img
+          class="post-img"
+          src="https://media.giphy.com/media/AFHFoEv9fDOn7lIdlD/giphy.gif"
+          alt="GIF of two people fist-bumbing with the caption 'YOU GOT THIS'"
+          style="width: 100%"
+        />
         <p>Carpe diem! <b>#wordsofencouragement</b> <b>#wordsofwisdom</b></p>
       </div>
     </li>


### PR DESCRIPTION
This pull request addresses a structural bug in the HTML code where the <h2> heading for "My Feed" was incorrectly placed inside the <ul> element.

Solution:
Placing heading elements inside a list can lead to confusion regarding the document structure and may affect accessibility for screen readers. By positioning the <h2> correctly, I enhance the readability and semantics of the HTML document, ensuring that it accurately reflects the content hierarchy