### PR TITLE
Remove unnecessary no-repeat from linear-gradient

### DIFF
--- a/1-selectors/05-concert-flyer/styles.css
+++ b/1-selectors/05-concert-flyer/styles.css
@@ -2,7 +2,7 @@
 /* Codédex */
 
 body {
-  background: linear-gradient(skyblue, green) no-repeat;
+  background: linear-gradient(skyblue, green);
   margin: 0;
   padding: 0;
   min-height: 100vh;


### PR DESCRIPTION
the no-repeat keyword is not necessary with linear-gradient