### PR TITLE
Fixed style.css at "section > h2{}" part

### DIFF
--- a/4-layout/24-sticky-elements/styles.css
+++ b/4-layout/24-sticky-elements/styles.css
@@ -51,7 +51,7 @@ footer > p {
 section > h2 {
   border-bottom: 0.5px solid grey;
   position: sticky;
-  top: 103px;
+  top: 133px;
 }
 
 #story-section {


### PR DESCRIPTION
The instruction of chapter "**Layout**" and exercise "**24. Sticky Elements**" says:

> Add a top property of 133px to the section > h2 selector.

At the solution the top property is set to **103px**. The main goal of this exercise that the section headers "Our Story" and "Services" stick towards the top of the page are not visible. 
Fixed the style.css to the mentioned **133px** of the instruction. 